### PR TITLE
Show a call stack when a syntax error occurs

### DIFF
--- a/callstackdemo.6502
+++ b/callstackdemo.6502
@@ -1,0 +1,22 @@
+org &2000
+
+macro add n
+	clc
+	adc #n
+endmacro
+
+macro add_twice n
+	add n
+	add n*2
+endmacro
+
+.start
+	lda &70
+	add_twice 4
+	add_twice 200
+	sta &70
+	rts
+
+.end
+
+save "test", start, end

--- a/src/asmexception.cpp
+++ b/src/asmexception.cpp
@@ -55,12 +55,24 @@ void AsmException_FileError::Print() const
 /*************************************************************************************************/
 void AsmException_SyntaxError::Print() const
 {
-	assert( m_filename != "" );
-	assert( m_lineNumber != 0 );
+	assert( !m_filename.empty() );
+	assert( !m_lineNumber.empty() );
+	assert( m_filename.size() == m_lineNumber.size() ) ;
 
-	cerr << m_filename << ":" << m_lineNumber << ": error: ";
+	cerr << m_filename[0] << ":" << m_lineNumber[0];
+	cerr << ": error: ";
 	cerr << Message() << endl << endl;
 	cerr << m_line << endl;
 	cerr << string( m_column, ' ' ) << "^" << endl;
+
+	if ( m_filename.size() > 1 )
+	{
+		cerr << endl;
+		cerr << "Call stack:" << endl;
+		for (size_t i = 1; i < m_filename.size(); i++)
+		{
+			cerr << m_filename[i] << ":" << m_lineNumber[i] << endl;
+		}
+	}
 }
 

--- a/src/asmexception.h
+++ b/src/asmexception.h
@@ -25,6 +25,7 @@
 
 
 #include <string>
+#include <vector>
 
 
 /*************************************************************************************************/
@@ -115,24 +116,20 @@ class AsmException_SyntaxError : public AsmException
 public:
 
 	AsmException_SyntaxError()
-		:	m_column( 0 ),
-                        m_filename( "" ),
-			m_lineNumber( 0 )
+		:	m_column( 0 )
 	{
 	}
 
 	AsmException_SyntaxError( std::string line, int column )
 		:	m_line( line ),
-			m_column( column ),
-			m_filename( "" ),
-			m_lineNumber( 0 )
+			m_column( column )
 	{
 	}
 
 	virtual ~AsmException_SyntaxError() {}
 
-	void SetFilename( const std::string& filename )	{ if ( m_filename == "" ) m_filename = filename; }
-	void SetLineNumber( int lineNumber )		{ if ( m_lineNumber == 0 ) m_lineNumber = lineNumber; }
+	void SetFilename( const std::string& filename )	{ m_filename.push_back( filename ); }
+	void SetLineNumber( int lineNumber )		{ m_lineNumber.push_back( lineNumber ); }
 
 	virtual void Print() const;
 	virtual const char* Message() const
@@ -144,9 +141,9 @@ public:
 protected:
 
 	std::string			m_line;
-	int					m_column;
-	std::string			m_filename;
-	int					m_lineNumber;
+	int				m_column;
+	std::vector<std::string>	m_filename;
+	std::vector<int>                m_lineNumber;
 };
 
 


### PR DESCRIPTION
This only has an effect when errors occur during macro expansion; "normal"
errors aren't affected. callstackdemo.6502 provides a trivial illustration of
this in action.