### PR TITLE
Allow label scope-jumping with .*foo and .^bar syntax

### DIFF
--- a/about.txt
+++ b/about.txt
@@ -529,6 +529,50 @@ IF...ELIF...ELSE...ENDIF
           RTS
       }
 
+  Labels can be defined within a scope which exist outside that scope in
+  two ways.
+
+  A label defined using '.*label' will be globally visible:
+  
+      .copy_10
+	  {
+	      LDX #10
+	  .*copy_x
+	      DEX
+	  .loop
+	      LDA from,X
+		  STA to,X
+		  DEX
+		  BPL loop
+		  RTS
+	  }
+
+	  JSR copy_10
+	  LDX #20
+	  JSR copy_x
+
+  A label defined using '.^label' will be visible in the parent scope:
+
+      .contrived
+	  {
+	      LDX #255
+		  {
+		      LDY #3
+		  .^loop
+			  DEX
+			  BEQ exit
+		      DEY
+			  BNE loop
+		  }
+		  LDY #7
+		  JMP loop ; .loop *is* visible here
+		  .exit
+		      RTS
+	  }
+	  JMP loop ; error, .loop is *not* visible here
+
+  For a more realistic example of the use of '.^label', see scopedemo2.6502.
+
 
 PUTFILE <host filename>, [<beeb filename>,] <start addr> [,<exec addr>]
 

--- a/scopejumpdemo1.6502
+++ b/scopejumpdemo1.6502
@@ -1,0 +1,27 @@
+ORG &2000
+
+.start
+
+	{
+		LDX #255
+		.loop
+			DEX
+			BNE loop
+	}
+
+	{
+		\ .loop128 is a global label and is visible outside of this scope
+		.*loop128
+		LDX #128
+		\ This .loop label here is independent of the previous one
+		.loop
+			DEX
+			BNE loop
+	}
+
+	\ JMP loop - this is an error, there is no .loop label visible
+	JMP loop128 \ this is fine
+
+.end
+
+SAVE "test", start, end

--- a/scopejumpdemo2.6502
+++ b/scopejumpdemo2.6502
@@ -1,0 +1,19 @@
+ORG &2000
+
+.start
+
+	LDA #65:STA &70
+	JSR foo
+	STY &71
+	JSR bar
+	
+	\ JMP ldy_3_and_rts \ this won't assemble, even though it exists inside
+	\ scopejumpdemo2foo.6502
+	LDY #3
+	RTS
+
+INCLUDE "scopejumpdemo2foo.6502"
+
+.end
+
+SAVE "test", start, end

--- a/scopejumpdemo2foo.6502
+++ b/scopejumpdemo2foo.6502
@@ -1,0 +1,49 @@
+\ This file is intended to be INCLUDEd by scopejumpdemo2.6502.
+\ Its entire contents are wrapped in a scope, so only labels we explicitly
+\ make global are available to the rest of the program.
+{
+
+	\ foo is a global label; this is a subroutine we are making available to
+	\ the rest of the program outside this file.
+	\
+	\ foo checks the contents of &70; if it's less than 42 we set X to 4,
+	\ otherwise we set X to 2. Either way, we set Y to 3.
+	.*foo
+	{
+		LDA &70
+		CMP #42
+		BCC lt_42
+		LDX #2
+		JMP ldy_3_and_rts
+	.lt_42
+		LDX #4
+	.^ldy_3_and_rts
+		LDY #3
+		RTS
+	}
+
+	\ bar is a global label; this is another subroutine we are making
+	\ available to the rest of the program.
+	\
+	\ bar checks the contents of &71; if it's less than 42 we set X to 9,
+	\ otherwise we set X to 7. Either way, we set Y to 3.
+	.*bar
+	{
+		\ Because we're part of the same "module", we happen to know that
+		\ the LDY #3:RTS code is available inside foo, so we can take 
+		\ advantage of that and not duplicate it here. This is an
+		\ implementation detail that might change, so we don't want that
+		\ exposing outside this file. Because we declared it ".^ldy_3_and_rts"
+		\ inside the scope enclosing foo's body, it's visible in the scope
+		\ which encloses this entire file, but not any parent scope.
+		LDA &71
+		CMP #42
+		BCC lt_42
+		LDX #7
+		JMP ldy_3_and_rts
+	.lt_42 \ local label, so doesn't clash with foo's lt_42
+		LDX #9
+		JMP ldy_3_and_rts
+	}
+
+}

--- a/src/asmexception.h
+++ b/src/asmexception.h
@@ -200,6 +200,8 @@ DEFINE_SYNTAX_EXCEPTION( NoIndexedX, "X indexed mode does not exist for this ins
 DEFINE_SYNTAX_EXCEPTION( NoIndexedY, "Y indexed mode does not exist for this instruction." );
 DEFINE_SYNTAX_EXCEPTION( LabelAlreadyDefined, "Symbol already defined." );
 DEFINE_SYNTAX_EXCEPTION( InvalidSymbolName, "Invalid symbol name; must start with a letter and contain only letters, numbers and underscore." );
+DEFINE_SYNTAX_EXCEPTION( SymbolScopeOutsideMacro, "Symbol scope cannot promote outside current macro." );
+DEFINE_SYNTAX_EXCEPTION( SymbolScopeOutsideFor, "Symbol scope cannot promote outside current FOR loop." );
 DEFINE_SYNTAX_EXCEPTION( SecondPassProblem, "Fatal error: the second assembler pass has generated different code to the first." );
 DEFINE_SYNTAX_EXCEPTION( InvalidMacroName, "Invalid macro name; must start with a letter and contain only letters, numbers and underscore." );
 DEFINE_SYNTAX_EXCEPTION( NoNestedMacros, "Cannot define one macro inside another." );

--- a/src/sourcecode.cpp
+++ b/src/sourcecode.cpp
@@ -545,3 +545,20 @@ void SourceCode::EndMacro( const string& line, int column )
 		m_currentMacro = NULL;
 	}
 }
+
+
+
+/*************************************************************************************************/
+/**
+	SourceCode::IsRealForLevel()
+
+	Is the relevant level in the for stack a real for loop or one of the special ones used
+        to implement braces?
+*/
+/*************************************************************************************************/
+bool SourceCode::IsRealForLevel( int level ) const
+{
+        assert( level > 0 );
+        assert( level <= m_forStackPtr );
+        return m_forStack[ level - 1 ].m_step != 0.0;
+}

--- a/src/sourcecode.h
+++ b/src/sourcecode.h
@@ -116,6 +116,7 @@ public:
 	void					CopyForStack( const SourceCode* copyFrom );
 
 	inline int 				GetForLevel() const { return m_forStackPtr; }
+	inline int 				GetInitialForStackPtr() const { return m_initialForStackPtr; }
 	inline Macro*			GetCurrentMacro() { return m_currentMacro; }
 
 	std::string				GetSymbolNameSuffix( int level = -1 ) const;
@@ -130,6 +131,7 @@ public:
 	void					RemoveIfLevel( const std::string& line, int column );
 	void					StartMacro( const std::string& line, int column );
 	void					EndMacro( const std::string& line, int column );
+	bool					IsRealForLevel( int level ) const;
 
 
 protected:


### PR DESCRIPTION
Documented in about.txt